### PR TITLE
Typo fix and code snippet update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ features:
 - title: An imperative API
   details: This means that you don't need to set component state or render elements to trigger notifications. Instead, just call a function. This makes it very user friendly for component library authors.
 - title: Render whatever you want
-  details: tilize the render callback to create entirely custom notifications.
+  details: utilize the render callback to create entirely custom notifications.
 - title: Functional default styles
   details: Import the provided css for some nice styling defaults or write your own styles.
 - title: JS agnostic notifications

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -26,6 +26,7 @@ You can then register ```breadstick``` as a plugin.
 ``` js
   import Vue from 'vue'
   import { BreadstickBakery } from 'breadstick'
+  import 'breadstick/dist/breadstick.css'
 
   Vue.use(BreadstickBakery)
   // You can now access the `breadstick` instance
@@ -36,6 +37,8 @@ By default, ```breadstick``` exports a class instance API you can use without th
 
 ``` js
   import Breadstick from 'breadstick'
+  import 'breadstick/dist/breadstick.css'
+
   const breadstick = new Breadstick()
 
   // You can now access the `breadstick` instance


### PR DESCRIPTION

## Description
Typo fix and code snippet update

## Motivation and Context
Fix a typo on the homepage misspelling utilize as tilize.
Also update code snippet to show importation of the default CSS of breadstick
